### PR TITLE
Fix access array offset on value of type null

### DIFF
--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -1924,7 +1924,7 @@ class Less_Parser{
 
 		$this->expectChar(']');
 
-		return $this->NewObj3('Less_Tree_Attribute',array( $key, $op[0], $val));
+		return $this->NewObj3('Less_Tree_Attribute',array( $key, $op === null ? null : $op[0], $val));
 	}
 
 	//

--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -218,8 +218,9 @@ class Less_Tree_Import extends Less_Tree{
 
 			}else{
 				//otherwise, the file should be relative to the server root
-				$import_dirs[ $this->currentFileInfo['entryPath'] ] = $this->currentFileInfo['entryUri'];
-
+				if( $this->currentFileInfo ) {
+					$import_dirs[ $this->currentFileInfo['entryPath'] ] = $this->currentFileInfo['entryUri'];
+				}
 				//if the user supplied entryPath isn't the actual root
 				$import_dirs[ $_SERVER['DOCUMENT_ROOT'] ] = '';
 


### PR DESCRIPTION
Since PHP 7.4, the following warning is thrown when we try to access array offsets of `null` values ([example](https://3v4l.org/BTIiR)):

```
Notice: Trying to access array offset on value of type null 
```

Let's fix this.