### PR TITLE
Fix open_basedir issues

### DIFF
--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -2813,4 +2813,25 @@ class Less_Parser{
 		return (Less_Parser::$options['cache_method'] && (Less_Cache::$cache_dir || (Less_Parser::$options['cache_method'] == 'callback')));
 	}
 
+	public static function IsAbsPath($path){
+		$path = (string) $path;
+		if ($path === '') {
+			return false;
+		}
+		if (preg_match('%^(\w+:)?//%', $path)) {
+			// URL
+			return true;
+		}
+		$path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
+		if ($path[0] === '/') {
+			// path starts with '/' (or with '\' on Windows)
+			return true;
+		}
+		if (DIRECTORY_SEPARATOR === '\\') {
+			if (preg_match('%^[a-z]:/%i', $path)) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -183,7 +183,7 @@ class Less_Tree_Import extends Less_Tree{
 		}
 
 		// optional (need to be before "CSS" to support optional CSS imports. CSS should be checked only if empty($this->currentFileInfo))
-		if( isset($this->options['optional']) && $this->options['optional'] && !file_exists($full_path) && (!$evald->css || !empty($this->currentFileInfo))) {
+		if( isset($this->options['optional']) && $this->options['optional'] && (!Less_Parser::IsAbsPath($full_path) || !file_exists($full_path)) && (!$evald->css || !empty($this->currentFileInfo))) {
 			return array();
 		}
 

--- a/test/Fixtures/open_basedir/existing.less
+++ b/test/Fixtures/open_basedir/existing.less
@@ -1,0 +1,1 @@
+.existing{color:green}

--- a/test/Fixtures/open_basedir/subfolder/main.less
+++ b/test/Fixtures/open_basedir/subfolder/main.less
@@ -1,0 +1,2 @@
+@import "../existing.less";
+@import (optional) "../not-existing.less";

--- a/test/phpunit/OpenBasedirTest.php
+++ b/test/phpunit/OpenBasedirTest.php
@@ -1,0 +1,34 @@
+<?php
+
+class OpenBasedirTest extends phpunit_bootstrap
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testOpenBasedir()
+    {
+        chdir($this->root_directory);
+        $previousOpenBasedir = ini_set('open_basedir', implode(PATH_SEPARATOR, array(
+            $this->root_directory,
+            sys_get_temp_dir(),
+        )));
+        if ($previousOpenBasedir === false) {
+            $this->markTestSkipped('Unable to change open_basedir');
+        }
+        $error = null;
+        $css = null;
+        try {
+            $parser = new Less_Parser(array());
+            $parser->parseFile($this->fixtures_dir . '/open_basedir'.'/subfolder/main.less');
+            $css = $parser->getCss();
+            
+        } catch (Exception $x) {
+            $error = $x;
+        } catch (Throwable $x) {
+            $error = $x;
+        }
+        $this->assertNull($error);
+        $this->assertSame('.existing{color:green}', preg_replace('/[\s;]+/', '', $css));
+    }
+}

--- a/test/phpunit/bootstrap.php
+++ b/test/phpunit/bootstrap.php
@@ -6,21 +6,22 @@ if (!class_exists(PHPUnit_Framework_TestCase::class)) {
 
 class phpunit_bootstrap extends PHPUnit_Framework_TestCase{
 
+	protected $root_directory;
 	public $fixtures_dir;
 	public $cache_dir;
 
 	function setUp(){
 		echo "\nSet-Up: ".get_class($this);
 
-		$root_directory = dirname(dirname(dirname(__FILE__)));
+		$this->root_directory = dirname(dirname(dirname(__FILE__)));
 
-		require_once( $root_directory . '/lib/Less/Autoloader.php' );
+		require_once( $this->root_directory . '/lib/Less/Autoloader.php' );
 		Less_Autoloader::register();
 
-		$this->fixtures_dir = $root_directory.'/test/Fixtures';
+		$this->fixtures_dir = $this->root_directory.'/test/Fixtures';
 		echo "\n  fixtures_dir: ".$this->fixtures_dir;
 
-		$this->cache_dir = $root_directory.'/test/phpunit/_cache/';
+		$this->cache_dir = $this->root_directory.'/test/phpunit/_cache/';
 		$this->CheckCacheDirectory();
 
 


### PR DESCRIPTION
Let's assume that:

- when we have an `@import` marked as `(optional)`, with a relative path starting with `../`
- the path does not actually exist

In that case, the library tries to look for the existence of that non existing path starting from the current directory.

This is an issue because:
- the current directory shouldn't affect the CSS generation
- in case of systems where the open_basedir is set, we may easily go out of the allowed path.

In this pull request, I start adding a test that shows this issue (that is, the TravisCI jobs should fail).

I'll add another commit once the TravisCI jobs complete.