### PR TITLE
Fixed test suite on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.1
   - 7
   - hhvm-3.18
+  - 7.4snapshot
   - nightly
 
 matrix:

--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -214,7 +214,9 @@ class Less_Tree_Import extends Less_Tree{
 
 			if( Less_Environment::isPathRelative($evald_path) ){
 				//if the path is relative, the file should be in the current directory
-				$import_dirs[ $this->currentFileInfo['currentDirectory'] ] = $this->currentFileInfo['uri_root'];
+				if ( $this->currentFileInfo ){
+					$import_dirs[ $this->currentFileInfo['currentDirectory'] ] = $this->currentFileInfo['uri_root'];
+				}
 
 			}else{
 				//otherwise, the file should be relative to the server root


### PR DESCRIPTION
According to the test suite, this is the only remaining incompatibility with PHP 7.4:
```
1) phpunit_FixturesTest::testLessJs
Trying to access array offset on value of type null

lib/Less/Tree/Import.php:221
lib/Less/Tree/Import.php:156
lib/Less/Tree/Ruleset.php:94
lib/Less/Parser.php:199
test/phpunit/FixturesTest.php:68
test/phpunit/FixturesTest.php:29
```