### PR TITLE
Simplify Composer installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,8 @@ You can install the library with Composer or manually.
 
 #### Composer
 
-Step 1. Edit your `composer.json`:
-
-```json
-{
-    "require": {
-        "wikimedia/less.php": "~1.8.2"
-    }
-}
-```
-
-Step 2. Install it:
-
-```bash
-$ curl -sS https://getcomposer.org/installer | php
-$ php composer.phar install
-```
+1. [Install Composer](https://getcomposer.org/download/)
+2. Run `composer require wikimedia/less.php`
 
 #### Manually From Release
 


### PR DESCRIPTION
Remove incorrect Composer installation instructions, and simplify the process of adding less.php to composer.json. There's no need to specify the version number in the readme; the latest stable version will be used.