### PR TITLE
Allow installation with PHP 7.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4']
+        php-version: ['7.1', '7.2', '7.3', '7.4']
 
     runs-on: ubuntu-latest
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.8.3
+- [All Changes](https://github.com/wikimedia/less.php/compare/1.8.2...1.8.3)
+- Allow installation with PHP 7.1 (Franz Liedke)
+
 # 1.8.2
 - [All Changes](https://github.com/wikimedia/less.php/compare/1.8.1...1.8.2)
 - Require PHP 7.2.9+, up from 5.3+ (James Forrester)

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		}
 	],
 	"require": {
-		"PHP" : ">=7.2.9"
+		"PHP" : ">=7.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "7.5.14"


### PR DESCRIPTION
Please allow me to make this proposal for resolving my compatibility problem outlined in https://github.com/wikimedia/less.php/pull/17#issuecomment-580886403. As explained there, making such a change in a patch release is not in line with semantic versioning (to the best of my knowledge) and could therefore be considered a bug.

@jdforrester commented:

> Note that PHP 7.1 stopped getting bug fixes in December 2018 and stopped getting security fixes in December 2019.

Let me start by saying that we are very aware of the importance of pushing people to upgrade their servers to run up-to-date and supported software; and I appreciate that you seem to be taking this seriously as well.

However, let me also add some nuance, from my personal perspective and experience:
- I think that the responsibility for pushing people to upgrade to supported PHP versions should lie with *application* developers, not so much with *library* developers. Generally I'd say that the lower (layer) the dependency, the more broad its compatibility should be. My rationale is that library devs target other devs (which are hopefully aware of the need to upgrade), whereas application devs have the chance to directly nudge the people who install / run the software.
- I can relate to wanting to adopt new features from the latest PHP versions and raising the requirements to be able to do so. However, as far as I can see no such changes have been made. It seems then that raising the version requirement was mostly made for ideological (for lack of a better term) reasons than as an actual *requirement*. IMHO, that's what Composer's `require` key should be used for - and not for arbitrarily preventing people from even installing this library; people that could add this kind of requirement at the top level.
- There are many reasons why people can not or do not upgrade immediately or in time for official maintenance cycles. I am not here to judge, it definitely happens.
- We definitely want to (and will) make the switch and require a PHP version above 7.2.0 soon(-ish), but we don't want to be forced to do so just to get PHP 7.4 compatibility. (In other words, I would rather add PHP 7.4 users to our user-base than throwing out others; or at least not at the same time and without a grace period.)
- I would rather let people upgrade their PHP application to the latest version on a slightly outdated PHP server, than preventing them from getting our own security upgrades.

To make this as easy as possible, I also updated the changelog. There is no more work for you than tagging a new release. :wink: I hope it helps.

Thanks for considering!

---

And last but not least, let me again thank you for keeping this library maintained! It's sorely needed and highly appreciated. :heart: 
