### PR TITLE
Make Less_Tree_Directive::__construct() $rules optional

### DIFF
--- a/lib/Less/Tree/Directive.php
+++ b/lib/Less/Tree/Directive.php
@@ -17,7 +17,7 @@ class Less_Tree_Directive extends Less_Tree{
 	public $debugInfo;
 	public $type = 'Directive';
 
-	public function __construct($name, $value = null, $rules, $index = null, $currentFileInfo = null, $debugInfo = null ){
+	public function __construct($name, $value = null, $rules = null, $index = null, $currentFileInfo = null, $debugInfo = null ){
 		$this->name = $name;
 		$this->value = $value;
 		if( $rules ){


### PR DESCRIPTION
From https://phabricator.wikimedia.org/T247934

```
Deprecated: Required parameter $rules follows optional parameter $value less.php/lib/Less/Tree/Directive.php on line 20
```