### PR TITLE
docs: Update CI badge in README.md

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: PHP Test
 
 on: [push,pull_request]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+[![Continuous Integration](https://github.com/wikimedia/less.php/workflows/PHP%20Test/badge.svg)](https://github.com/wikimedia/less.php/actions)
+
 [Less.php](http://lessphp.typesettercms.com)
 ========
 
-This is the Wikimedia fork of a PHP port of the official LESS processor <http://lesscss.org>. [![Build Status](https://travis-ci.org/wikimedia/less.php.png?branch=master)](https://travis-ci.org/wikimedia/less.php)
+This is the Wikimedia fork of a PHP port of the official LESS processor <http://lesscss.org>.
 
 * [About](#about)
 * [Installation](#installation)


### PR DESCRIPTION
Change the README badge from Travis (which we've disabled) to GitHub Workflows.

Also add a label to the build that's more suitable for display in such badge.