### PR TITLE
build: Simplify export ignores in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
-.gitattributes export-ignore
-.github/ export-ignore
-.gitignore export-ignore
-.travis.yml export-ignore
-phpunit.xml export-ignore
-test/ export-ignore
+/.* export-ignore
+/test/ export-ignore
+/phpunit.xml export-ignore


### PR DESCRIPTION
* Use a wildcard, and thus remove the obsolete entry
  for .travis.yml.

* Anchor to root directory.