### PR TITLE
docs: Minor improvements, and misc updates to reflect Wikimedia fork

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,70 +1,72 @@
-# 3.1.0
-- [All Changes](https://github.com/wikimedia/less.php/compare/v3.0.0...v3.1.0)
-* PHP 8.0 support: Drop use of curly braces for sub-string eval (James D. Forrester)
+## 3.1.0
+
+* [All changes](https://github.com/wikimedia/less.php/compare/v3.0.0...v3.1.0)
+* Add PHP 8.0 support: Drop use of curly braces for sub-string eval (James D. Forrester)
 * Make `Directive::__construct` $rules arg optional (fix PHP 7.4 warning) (Sam Reed)
 * ProcessExtends: Improve performance by using a map for selectors and parents (Andrey Legayev)
-* build: Run CI tests on PHP 8.0 too (James D. Forrester)
-* code: Fix PSR12.Properties.ConstantVisibility.NotFound (Sam Reed)
 
-# 3.0.0
-- [All Changes](https://github.com/wikimedia/less.php/compare/v2.0.0...v3.0.0)
-- Raise PHP requirement from 7.1 to 7.2.9 (James Forrester)
-- build: Upgrade phpunit to ^8.5 and make pass  (James Forrester)
-- build: Install php-parallel-lint  (James Forrester)
-- build: Install minus-x and make pass  (James Forrester)
+## 3.0.0
 
-# 2.0.0
-- [All Changes](https://github.com/wikimedia/less.php/compare/1.8.2...v2.0.0)
-- Relax PHP requirement down to 7.1, from 7.2.9 (Franz Liedke)
-- Reflect recent breaking changes properly with the semantic versioning (James Forrester)
+* [All changes](https://github.com/wikimedia/less.php/compare/v2.0.0...v3.0.0)
+* Raise PHP requirement from 7.1 to 7.2.9 (James Forrester)
 
-# 1.8.2
-- [All Changes](https://github.com/wikimedia/less.php/compare/1.8.1...1.8.2)
-- Require PHP 7.2.9+, up from 5.3+ (James Forrester)
-- Release: Update Version.php with the current release ID (COBadger)
-- Fix access array offset on value of type null (Michele Locati)
-- Fixed test suite on PHP 7.4 (Sergei Morozov)
-- docs: Fix 1.8.1 "All changes" link (Timo Tijhof)
+## 2.0.0
 
-# 1.8.1
-- [All Changes](https://github.com/wikimedia/less.php/compare/v1.8.0...1.8.1)
-- Another PHP 7.3 compatibility tweak
+* [All changes](https://github.com/wikimedia/less.php/compare/v1.8.2...v2.0.0)
+* Relax PHP requirement down to 7.1, from 7.2.9 (Franz Liedke)
+* Reflect recent breaking changes properly with the semantic versioning (James Forrester)
 
-# 1.8.0
-- [All Changes](https://github.com/Asenar/less.php/compare/v1.7.0.13...v1.8.0)
-- Wikimedia fork
-- Supports up to PHP 7.3
-- No longer tested against PHP 5, though it's still remains allowed in `composer.json` for HHVM compatibility
-- Switched to [semantic versioning](https://semver.org/), hence version numbers now use 3 digits
+## 1.8.2
 
-# 1.7.0.13
- - [All Changes](https://github.com/Asenar/less.php/compare/v1.7.0.12...v1.7.0.13)
- - Fix composer.json (PSR-4 was invalid)
+* [All changes](https://github.com/wikimedia/less.php/compare/v1.8.1...v1.8.2)
+* Require PHP 7.2.9+, up from 5.3+ (James Forrester)
+* release: Update Version.php with the current release ID (COBadger)
+* Fix access array offset on value of type null (Michele Locati)
+* Fix test suite on PHP 7.4 (Sergei Morozov)
 
-# 1.7.0.12
- - [All Changes](https://github.com/Asenar/less.php/compare/v1.7.0.11...v1.7.0.12)
- - set bin/lessc bit executable
- - Add 'gettingVariables' method in Less_Parser
+## 1.8.1
 
-# 1.7.0.11
- - [All Changes](https://github.com/Asenar/less.php/compare/v1.7.0.10...v1.7.0.11)
- - Fix realpath issue (windows)
- - Set Less_Tree_Call property back to public ( Fix 258 266 267 issues from oyejorge/less.php)
+* [All changes](https://github.com/wikimedia/less.php/compare/v1.8.0...v1.8.1)
+* Another PHP 7.3 compatibility tweak
 
-# 1.7.0.10
+## 1.8.0
 
- - [All Changes](https://github.com/oyejorge/less.php/compare/v1.7.0.9...v1.7.10)
- - Add indentation option
- - Add 'optional' modifier for @import
- - fix $color in Exception messages
- - don't use set_time_limit when running cli
- - take relative-url into account when building the cache filename
- - urlArgs should be string no array()
- - add bug-report fixtures [#6dc898f](https://github.com/oyejorge/less.php/commit/6dc898f5d75b447464906bdf19d79c2e19d95e33)
- - fix #269, missing on NameValue type [#a8dac63](https://github.com/oyejorge/less.php/commit/a8dac63d93fb941c54fb78b12588abf635747c1b)
+Library forked by Wikimedia, from [oyejorge/less.php](https://github.com/oyejorge/less.php).
 
-# 1.7.0.9
+* [All changes](https://github.com/wikimedia/less.php/compare/v1.7.0.13...v1.8.0)
+* Supports up to PHP 7.3
+* No longer tested against PHP 5, though it's still remains allowed in `composer.json` for HHVM compatibility
+* Switched to [semantic versioning](https://semver.org/), hence version numbers now use 3 digits
 
- - [All Changes](https://github.com/oyejorge/less.php/compare/v1.7.0.8...v1.7.0.9)
- - Remove space at beginning of Version.php
- - Revert require() paths in test interface
+## 1.7.0.13
+
+* [All changes](https://github.com/wikimedia/less.php/compare/v1.7.0.12...v1.7.0.13)
+* Fix composer.json (PSR-4 was invalid)
+
+## 1.7.0.12
+
+* [All changes](https://github.com/wikimedia/less.php/compare/v1.7.0.11...v1.7.0.12)
+* set bin/lessc bit executable
+* Add `gettingVariables` method to `Less_Parser`
+
+## 1.7.0.11
+
+* [All changes](https://github.com/wikimedia/less.php/compare/v1.7.0.10...v1.7.0.11)
+* Fix realpath issue (windows)
+* Set Less_Tree_Call property back to public ( Fix 258 266 267 issues from oyejorge/less.php)
+
+## 1.7.0.10
+
+* [All changes](https://github.com/wikimedia/less.php/compare/v1.7.0.9...v1.7.10)
+* Add indentation option
+* Add `optional` modifier for @import
+* Fix $color in Exception messages
+* take relative-url into account when building the cache filename
+* urlArgs should be string no array()
+* fix missing on NameValue type [#269](https://github.com/oyejorge/less.php/issues/269)
+
+## 1.7.0.9
+
+* [All changes](https://github.com/wikimedia/less.php/compare/v1.7.0.8...v1.7.0.9)
+* Remove space at beginning of Version.php
+* Revert require() paths in test interface

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Continuous Integration](https://github.com/wikimedia/less.php/workflows/PHP%20Test/badge.svg)](https://github.com/wikimedia/less.php/actions)
+[![Build Status](https://github.com/wikimedia/less.php/actions/workflows/php.yml/badge.svg)](https://github.com/wikimedia/less.php/actions)
 
-[Less.php](http://lessphp.typesettercms.com)
+Less.php
 ========
 
-This is the Wikimedia fork of a PHP port of the official LESS processor <http://lesscss.org>.
+This is a PHP port of the [official LESS processor](https://lesscss.org).
 
 * [About](#about)
 * [Installation](#installation)
@@ -15,17 +15,15 @@ This is the Wikimedia fork of a PHP port of the official LESS processor <http://
 * [Transitioning from Leafo/lessphp](#transitioning-from-leafolessphp)
 * [Credits](#credits)
 
-
-
 About
 ---
-The code structure of less.php mirrors that of the official processor which helps us ensure compatibility and allows for easy maintenance.
+
+The code structure of Less.php mirrors that of the official processor which helps us ensure compatibility and allows for easy maintenance.
 
 Please note, there are a few unsupported LESS features:
 
 - Evaluation of JavaScript expressions within back-ticks (for obvious reasons).
 - Definition of custom functions.
-
 
 Installation
 ---
@@ -37,11 +35,11 @@ You can install the library with Composer or manually.
 1. [Install Composer](https://getcomposer.org/download/)
 2. Run `composer require wikimedia/less.php`
 
-#### Manually From Release
+#### Manually from release
 
-Step 1. [Download a release](https://github.com/wikimedia/less.php/releases) and upload the PHP files to your server.
+1. [Download a release](https://github.com/wikimedia/less.php/releases) and upload the PHP files to your server.
 
-Step 2. Include the library:
+2. Include the library:
 
 ```php
 require_once '[path to less.php]/lib/Less/Autoloader.php';
@@ -51,7 +49,7 @@ Less_Autoloader::register();
 Basic Use
 ---
 
-#### Parsing Strings
+#### Parsing strings
 
 ```php
 $parser = new Less_Parser();
@@ -60,7 +58,7 @@ $css = $parser->getCss();
 ```
 
 
-#### Parsing LESS Files
+#### Parsing LESS files
 The parseFile() function takes two arguments:
 
 1. The absolute path of the .less file to be parsed
@@ -68,27 +66,27 @@ The parseFile() function takes two arguments:
 
 ```php
 $parser = new Less_Parser();
-$parser->parseFile( '/var/www/mysite/bootstrap.less', 'http://example.com/mysite/' );
+$parser->parseFile( '/var/www/mysite/bootstrap.less', 'https://example.org/mysite/' );
 $css = $parser->getCss();
 ```
 
+#### Handling invalid LESS
 
-#### Handling Invalid LESS
 An exception will be thrown if the compiler encounters invalid LESS.
 
 ```php
 try{
 	$parser = new Less_Parser();
-	$parser->parseFile( '/var/www/mysite/bootstrap.less', 'http://example.com/mysite/' );
+	$parser->parseFile( '/var/www/mysite/bootstrap.less', 'https://example.org/mysite/' );
 	$css = $parser->getCss();
 }catch(Exception $e){
 	$error_message = $e->getMessage();
 }
 ```
 
+#### Parsing multiple sources
 
-#### Parsing Multiple Sources
-less.php can parse multiple sources to generate a single CSS file.
+Less.php can parse multiple sources to generate a single CSS file.
 
 ```php
 $parser = new Less_Parser();
@@ -97,8 +95,9 @@ $parser->parse( '@color: #4D926F; #header { color: @color; } h2 { color: @color;
 $css = $parser->getCss();
 ```
 
-#### Getting Info About The Parsed Files
-less.php can tell you which .less files were imported and parsed.
+#### Getting info about the parsed files
+
+Less.php can tell you which `.less` files were imported and parsed.
 
 ```php
 $parser = new Less_Parser();
@@ -107,21 +106,23 @@ $css = $parser->getCss();
 $imported_files = $parser->allParsedFiles();
 ```
 
+#### Compressing output
 
-#### Compressing Output
-You can tell less.php to remove comments and whitespace to generate minimized CSS files.
+You can tell Less.php to remove comments and whitespace to generate minimized CSS files.
 
 ```php
-$options = array( 'compress'=>true );
+$options = [ 'compress' => true ];
 $parser = new Less_Parser( $options );
 $parser->parseFile( '/var/www/mysite/bootstrap.less', '/mysite/' );
 $css = $parser->getCss();
 ```
 
-#### Getting Variables
-You can use the getVariables() method to get an all variables defined and
+#### Getting variables
+
+You can use the `getVariables()` method to get an all variables defined and
 their value in a php associative array. Note that LESS has to be previously
 compiled.
+
 ```php
 $parser = new Less_Parser;
 $parser->parseFile( '/var/www/mysite/bootstrap.less');
@@ -130,117 +131,122 @@ $variables = $parser->getVariables();
 
 ```
 
+#### Setting variables
 
-
-#### Setting Variables
-You can use the ModifyVars() method to customize your CSS if you have variables stored in PHP associative arrays.
+You can use the `ModifyVars()` method to customize your CSS if you have variables stored in PHP associative arrays.
 
 ```php
 $parser = new Less_Parser();
 $parser->parseFile( '/var/www/mysite/bootstrap.less', '/mysite/' );
-$parser->ModifyVars( array('font-size-base'=>'16px') );
+$parser->ModifyVars( [ 'font-size-base' => '16px' ] );
 $css = $parser->getCss();
 ```
 
+#### Import directories
 
-#### Import Directories
-By default, less.php will look for @imports in the directory of the file passed to parseFile().
-If you're using parse() or if @imports reside in different directories, you can tell less.php where to look.
+By default, Less.php will look for imported files in the directory of the file passed to `parseFile()`.
+If you're using `parse()`, or if import files reside in a different directory, you can tell Less.php where to look.
 
 ```php
-$directories = array( '/var/www/mysite/bootstrap/' => '/mysite/bootstrap/' );
+$directories = [ '/var/www/mysite/bootstrap/' => '/mysite/bootstrap/' ];
 $parser = new Less_Parser();
 $parser->SetImportDirs( $directories );
 $parser->parseFile( '/var/www/mysite/theme.less', '/mysite/' );
 $css = $parser->getCss();
 ```
 
-
 Caching
 ---
-Compiling LESS code into CSS is a time consuming process, caching your results is highly recommended.
 
+Compiling LESS code into CSS is a time-consuming process, caching your results is highly recommended.
 
 #### Caching CSS
-Use the Less_Cache class to save and reuse the results of compiled LESS files.
-This method will check the modified time and size of each LESS file (including imported files) and regenerate a new CSS file when changes are found.
+
+Use the `Less_Cache` class to save and reuse the results of compiled LESS files.
+This class will check the modified time and size of each LESS file (including imported files) and regenerate a new CSS file when changes are found.
+
 Note: When changes are found, this method will return a different file name for the new cached content.
 
 ```php
-$less_files = array( '/var/www/mysite/bootstrap.less' => '/mysite/' );
-$options = array( 'cache_dir' => '/var/www/writable_folder' );
+$less_files = [ '/var/www/mysite/bootstrap.less' => '/mysite/' ];
+$options = [ 'cache_dir' => '/var/www/writable_folder' ];
 $css_file_name = Less_Cache::Get( $less_files, $options );
 $compiled = file_get_contents( '/var/www/writable_folder/'.$css_file_name );
 ```
 
-#### Caching CSS With Variables
-Passing options to Less_Cache::Get()
+#### Caching CSS with variables
+
+Passing options to `Less_Cache::Get()`:
 
 ```php
-$less_files = array( '/var/www/mysite/bootstrap.less' => '/mysite/' );
-$options = array( 'cache_dir' => '/var/www/writable_folder' );
-$variables = array( 'width' => '100px' );
+$less_files = [ '/var/www/mysite/bootstrap.less' => '/mysite/' ];
+$options = [ 'cache_dir' => '/var/www/writable_folder' ];
+$variables = [ 'width' => '100px' ];
 $css_file_name = Less_Cache::Get( $less_files, $options, $variables );
 $compiled = file_get_contents( '/var/www/writable_folder/'.$css_file_name );
 ```
 
+#### Parser caching
 
-#### Parser Caching
-less.php will save serialized parser data for each .less file if a writable folder is passed to the SetCacheDir() method.
+Less.php will save serialized parser data for each `.less` file if a writable folder is passed to the `SetCacheDir()` method.
+
 Note: This feature only caches intermediate parsing results to improve the performance of repeated CSS generation.
-Your application should cache any CSS generated by less.php.
+
+Your application should cache any CSS generated by Less.php.
 
 ```php
-$options = array('cache_dir'=>'/var/www/writable_folder');
+$options = [ 'cache_dir'=>'/var/www/writable_folder' ];
 $parser = new Less_Parser( $options );
 $parser->parseFile( '/var/www/mysite/bootstrap.less', '/mysite/' );
 $css = $parser->getCss();
 ```
 
-You can specify the caching technique used by changing the ```cache_method``` option. Supported methods are:
-* ```php```: Creates valid PHP files which can be included without any changes (default method).
-* ```var_export```: Like "php", but using PHP's ```var_export()``` function without any optimizations.
+You can specify the caching technique used by changing the `cache_method` option. Supported methods are:
+
+* `php`: Creates valid PHP files which can be included without any changes (default method).
+* `var_export`: Like "php", but using PHP's `var_export()` function without any optimizations.
   It's recommended to use "php" instead.
-* ```serialize```: Faster, but pretty memory-intense.
-* ```callback```: Use custom callback functions to implement your own caching method. Give the "cache_callback_get" and
-  "cache_callback_set" options with callables (see PHP's ```call_user_func()``` and ```is_callable()``` functions). less.php
-  will pass the parser object (class ```Less_Parser```), the path to the parsed .less file ("/some/path/to/file.less") and
-  an identifier that will change every time the .less file is modified. The ```get``` callback must return the ruleset
-  (an array with ```Less_Tree``` objects) provided as fourth parameter of the ```set``` callback. If something goes wrong,
-  return ```NULL``` (cache doesn't exist) or ```FALSE```.
+* `serialize`: Faster, but pretty memory-intense.
+* `callback`: Use custom callback functions to implement your own caching method. Give the "cache_callback_get" and
+  "cache_callback_set" options with callables (see PHP's `call_user_func()` and `is_callable()` functions). Less.php
+  will pass the parser object (class `Less_Parser`), the path to the parsed .less file ("/some/path/to/file.less") and
+  an identifier that will change every time the .less file is modified. The `get` callback must return the ruleset
+  (an array with `Less_Tree` objects) provided as fourth parameter of the `set` callback. If something goes wrong,
+  return `NULL` (cache doesn't exist) or `FALSE`.
 
 
-
-Source Maps
+Source maps
 ---
-Less.php supports v3 sourcemaps
+
+Less.php supports v3 sourcemaps.
 
 #### Inline
+
 The sourcemap will be appended to the generated CSS file.
 
 ```php
-$options = array( 'sourceMap' => true );
+$options = [ 'sourceMap' => true ];
 $parser = new Less_Parser($options);
 $parser->parseFile( '/var/www/mysite/bootstrap.less', '/mysite/' );
 $css = $parser->getCss();
 ```
 
-#### Saving to Map File
+#### Saving to map file
 
 ```php
-$options = array(
-	'sourceMap'			=> true,
-	'sourceMapWriteTo'	=> '/var/www/mysite/writable_folder/filename.map',
-	'sourceMapURL'		=> '/mysite/writable_folder/filename.map',
-	);
+$options = [
+	'sourceMap' => true,
+	'sourceMapWriteTo' => '/var/www/mysite/writable_folder/filename.map',
+	'sourceMapURL' => '/mysite/writable_folder/filename.map',
+];
 $parser = new Less_Parser($options);
 $parser->parseFile( '/var/www/mysite/bootstrap.less', '/mysite/' );
 $css = $parser->getCss();
 ```
-
 
 Command line
 ---
+
 An additional script has been included to use the compiler from the command line.
 In the simplest invocation, you specify an input file and the compiled CSS is written to standard out:
 
@@ -248,7 +254,7 @@ In the simplest invocation, you specify an input file and the compiled CSS is wr
 $ lessc input.less > output.css
 ```
 
-By using the -w flag you can watch a specified input file and have it compile as needed to the output file:
+By using the `-w` flag you can watch a specified input file and have it compile as needed to the output file:
 
 ```
 $ lessc -w input.less output.css
@@ -268,7 +274,7 @@ This library can be used as drop-in replacement of lessphp to work with [Drupal 
 
 How to install:
 
-1. [Download the less.php source code](https://github.com/wikimedia/less.php/archive/master.zip) and unzip it so that 'lessc.inc.php' is located at 'sites/all/libraries/lessphp/lessc.inc.php'.
+1. [Download the Less.php source code](https://github.com/wikimedia/less.php/archive/master.zip) and unzip it so that 'lessc.inc.php' is located at 'sites/all/libraries/lessphp/lessc.inc.php'.
 2. Download and install [Drupal 7 less module](https://drupal.org/project/less) as usual.
 3. That's it :)
 
@@ -283,15 +289,15 @@ How to use / install:
 3. Enter your LESS code in the text area and press (re)compile
 
 Use the built-in compiler to:
-- set any [Bootstrap](http://getbootstrap.com/customize/) variable or use Bootstrap's mixins:
-	-`@navbar-default-color: blue;`
+- set any [Bootstrap](https://getbootstrap.com/docs/3.4/customize/) variable or use Bootstrap's mixins:
+	- `@navbar-default-color: blue;`
         - create a custom button: `.btn-custom {
   .button-variant(white; red; blue);
 }`
 - set any built-in LESS variable: for example `@footer_bg_color: black;` sets the background color of the footer to black
 - use built-in mixins: - add a custom font: `.include-custom-font(@family: arial,@font-path, @path: @custom-font-dir, @weight: normal, @style: normal);`
 
-The compiler can also be downloaded as [plugin](http://wordpress.org/plugins/wp-less-to-css/)
+The compiler can also be downloaded as [plugin](https://wordpress.org/plugins/wp-less-to-css/)
 
 #### WordPress
 
@@ -299,17 +305,18 @@ This simple plugin will simply make the library available to other plugins and t
 
 How to install:
 
-1. Install the plugin from your WordPress Dashboard: http://wordpress.org/plugins/lessphp/
+1. Install the plugin from your WordPress Dashboard: https://wordpress.org/plugins/lessphp/
 2. That's it :)
 
 
 Transitioning from Leafo/lessphp
 ---
-Projects looking for an easy transition from leafo/lessphp can use the lessc.inc.php adapter. To use, [Download the less.php source code](https://github.com/wikimedia/less.php/archive/master.zip) and unzip the files into your project so that the new 'lessc.inc.php' replaces the existing 'lessc.inc.php'.
 
-Note, the 'setPreserveComments' will no longer have any effect on the compiled LESS.
+Projects looking for an easy transition from leafo/lessphp can use the lessc.inc.php adapter. To use, [Download the Less.php source code](https://github.com/wikimedia/less.php/archive/master.zip) and unzip the files into your project so that the new `lessc.inc.php` replaces the existing `lessc.inc.php`.
+
+Note, the `setPreserveComments` will no longer have any effect on the compiled LESS.
 
 Credits
 ---
-less.php was originally ported to PHP by [Matt Agar](https://github.com/agar) and then updated by [Martin Jantošovič](https://github.com/Mordred). This Wikimedia-maintained fork was split off from [Josh Schmidt's version](https://github.com/oyejorge/less.php).
 
+Less.php was originally ported to PHP in 2011 by [Matt Agar](https://github.com/agar) and then updated by [Martin Jantošovič](https://github.com/Mordred) in 2012. From 2013 to 2017, [Josh Schmidt](https://github.com/oyejorge) lead development of the library. Since 2019, the library is maintained by Wikimedia.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "wikimedia/less.php",
-	"description": "PHP port of the Javascript version of LESS http://lesscss.org (Originally maintained by Josh Schmidt)",
+	"description": "PHP port of the LESS processor",
 	"keywords": [ "less", "css", "php", "stylesheet", "less.js", "lesscss" ],
 	"license": "Apache-2.0",
 	"authors": [

--- a/lib/Less/Functions.php
+++ b/lib/Less/Functions.php
@@ -5,7 +5,7 @@
  *
  * @package Less
  * @subpackage function
- * @see http://lesscss.org/functions/
+ * @see https://lesscss.org/functions/
  */
 class Less_Functions {
 
@@ -385,7 +385,7 @@ return $a / $b;
 
 	//
 	// Copyright (c) 2006-2009 Hampton Catlin, Nathan Weizenbaum, and Chris Eppstein
-	// http://sass-lang.com
+	// https://sass-lang.com/
 	//
 
 	/**
@@ -1014,7 +1014,7 @@ return $a / $b;
 	}
 
 	// Color Blending
-	// ref: http://www.w3.org/TR/compositing-1
+	// ref: https://www.w3.org/TR/compositing-1/
 
 	public function colorBlend( $mode, $color1, $color2 ) {
 		$ab = $color1->alpha;	// backdrop

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    processIsolation = "false"
-    stopOnFailure = "false"
-    stopOnError = "false"
-    stopOnIncomplete="false"
-    stopOnSkipped="false"
-    bootstrap = "test/phpunit/bootstrap.php"
-    >
-
-    <testsuites>
-        <testsuite name="Less.php Test Suite">
-            <directory>./test/phpunit</directory>
-        </testsuite>
-    </testsuites>
-
+	processIsolation="false"
+	stopOnFailure="false"
+	stopOnError="false"
+	stopOnIncomplete="false"
+	stopOnSkipped="false"
+	bootstrap="test/phpunit/bootstrap.php"
+>
+	<testsuites>
+		<testsuite name="Test Suite">
+			<directory>./test/phpunit</directory>
+		</testsuite>
+	</testsuites>
 </phpunit>
 

--- a/test/php-diff/lib/Diff.php
+++ b/test/php-diff/lib/Diff.php
@@ -38,9 +38,9 @@
  * @package Diff
  * @author Chris Boulton <chris.boulton@interspire.com>
  * @copyright (c) 2009 Chris Boulton
- * @license New BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @license New BSD License https://opensource.org/licenses/bsd-license
  * @version 1.1
- * @link http://github.com/chrisboulton/php-diff
+ * @link https://github.com/chrisboulton/php-diff
  */
 
 class Diff {

--- a/test/php-diff/lib/Diff/Renderer/Abstract.php
+++ b/test/php-diff/lib/Diff/Renderer/Abstract.php
@@ -35,9 +35,9 @@
  * @package DiffLib
  * @author Chris Boulton <chris.boulton@interspire.com>
  * @copyright (c) 2009 Chris Boulton
- * @license New BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @license New BSD License https://opensource.org/licenses/bsd-license
  * @version 1.1
- * @link http://github.com/chrisboulton/php-diff
+ * @link https://github.com/chrisboulton/php-diff
  */
 
 abstract class Diff_Renderer_Abstract {

--- a/test/php-diff/lib/Diff/Renderer/Html/Array.php
+++ b/test/php-diff/lib/Diff/Renderer/Html/Array.php
@@ -35,9 +35,9 @@
  * @package DiffLib
  * @author Chris Boulton <chris.boulton@interspire.com>
  * @copyright (c) 2009 Chris Boulton
- * @license New BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @license New BSD License https://opensource.org/licenses/bsd-license
  * @version 1.1
- * @link http://github.com/chrisboulton/php-diff
+ * @link https://github.com/chrisboulton/php-diff
  */
 
 require_once dirname( __FILE__ ).'/../Abstract.php';

--- a/test/php-diff/lib/Diff/Renderer/Html/Inline.php
+++ b/test/php-diff/lib/Diff/Renderer/Html/Inline.php
@@ -35,9 +35,9 @@
  * @package DiffLib
  * @author Chris Boulton <chris.boulton@interspire.com>
  * @copyright (c) 2009 Chris Boulton
- * @license New BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @license New BSD License https://opensource.org/licenses/bsd-license
  * @version 1.1
- * @link http://github.com/chrisboulton/php-diff
+ * @link https://github.com/chrisboulton/php-diff
  */
 
 require_once dirname( __FILE__ ).'/Array.php';

--- a/test/php-diff/lib/Diff/Renderer/Html/SideBySide.php
+++ b/test/php-diff/lib/Diff/Renderer/Html/SideBySide.php
@@ -35,9 +35,9 @@
  * @package DiffLib
  * @author Chris Boulton <chris.boulton@interspire.com>
  * @copyright (c) 2009 Chris Boulton
- * @license New BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @license New BSD License https://opensource.org/licenses/bsd-license
  * @version 1.1
- * @link http://github.com/chrisboulton/php-diff
+ * @link https://github.com/chrisboulton/php-diff
  */
 
 require_once dirname( __FILE__ ).'/Array.php';

--- a/test/php-diff/lib/Diff/Renderer/Text/Context.php
+++ b/test/php-diff/lib/Diff/Renderer/Text/Context.php
@@ -35,9 +35,9 @@
  * @package DiffLib
  * @author Chris Boulton <chris.boulton@interspire.com>
  * @copyright (c) 2009 Chris Boulton
- * @license New BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @license New BSD License https://opensource.org/licenses/bsd-license
  * @version 1.1
- * @link http://github.com/chrisboulton/php-diff
+ * @link https://github.com/chrisboulton/php-diff
  */
 
 require_once dirname( __FILE__ ).'/../Abstract.php';

--- a/test/php-diff/lib/Diff/Renderer/Text/Unified.php
+++ b/test/php-diff/lib/Diff/Renderer/Text/Unified.php
@@ -35,9 +35,9 @@
  * @package DiffLib
  * @author Chris Boulton <chris.boulton@interspire.com>
  * @copyright (c) 2009 Chris Boulton
- * @license New BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @license New BSD License https://opensource.org/licenses/bsd-license
  * @version 1.1
- * @link http://github.com/chrisboulton/php-diff
+ * @link https://github.com/chrisboulton/php-diff
  */
 
 require_once dirname( __FILE__ ).'/../Abstract.php';

--- a/test/php-diff/lib/Diff/SequenceMatcher.php
+++ b/test/php-diff/lib/Diff/SequenceMatcher.php
@@ -35,9 +35,9 @@
  * @package Diff
  * @author Chris Boulton <chris.boulton@interspire.com>
  * @copyright (c) 2009 Chris Boulton
- * @license New BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @license New BSD License https://opensource.org/licenses/bsd-license
  * @version 1.1
- * @link http://github.com/chrisboulton/php-diff
+ * @link https://github.com/chrisboulton/php-diff
  */
 
 class Diff_SequenceMatcher {


### PR DESCRIPTION
* Consistent casing of "Less.php" as library name, `backticks` of identifiers, and sentence case for headings per Wikimedia's usual style.
* Expand the Credits section a bit more.
* Update some links to use HTTPS where possible.
* Remove links to typesettercms.com, which we don't own or update.
* Consistently use the vX.Y.Z format for these links (for one or two releases, both existed upstream, which our fork inherited, thats fine but we don't have to use them in in links).
* Consistently link to our fork (all tags exist in this repo).
* Use H2 headings in changelog, and fix some inconsistent line breaks and bullet formatting. Also prune entries a little bit of non-userfacing changes (link to full changes remains available).

Ref https://github.com/wikimedia/less.php/issues/43.