### PR TITLE
build: Add coverage to CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,27 +1,38 @@
-name: PHP Test
+name: Test
 
-on: [push,pull_request]
+on:
+  - push
+  - pull_request
 
 jobs:
-  build:
-    name: Test PHP ${{ matrix.php-version }}
+  php:
+    name: PHP ${{ matrix.php }}
 
     strategy:
+      fail-fast: false
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0']
+        include:
+          # Includes php7.1 - 8.0 and composer 2
+          # https://github.com/actions/virtual-environments/blob/ubuntu18/20210318.0/images/linux/Ubuntu1804-README.md#php
+          - php: '7.2'
+            os: ubuntu-18.04
+          - php: '7.3'
+            os: ubuntu-18.04
+          # Includes php7.4 - 8.0 and composer 2
+          # https://github.com/actions/virtual-environments/blob/ubuntu20/20210318.0/images/linux/Ubuntu2004-README.md#php
+          - php: '7.4'
+            os: ubuntu-20.04
+          - php: '8.0'
+            os: ubuntu-20.04
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
-    - name: Setup PHP, with composer and extensions
-      uses: shivammathur/setup-php@master
-      with:
-        php-version: ${{ matrix.php-version }}
-        extension-csv: dom, mbstring
-        # coverage: xdebug
+    - name: Use PHP ${{ matrix.php }}
+      run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php }}
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -29,5 +40,35 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-suggest
 
-    - name: Run test suite
-      run: composer run-script test
+    - name: Test
+      run: composer test
+
+  php-cover:
+    name: PHP ${{ matrix.php }} coverage
+
+    strategy:
+      matrix:
+        include:
+          # PHPUnit 8.5 does not support code coverage on PHP 8
+          - php: '7.4'
+            os: ubuntu-20.04
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Use PHP ${{ matrix.php }}
+      run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php }}
+
+    - name: Validate
+      run: composer validate
+
+    - name: Install
+      run: composer install --prefer-dist --no-progress --no-suggest
+
+    - name: Test with coverage
+      run: composer cover
+      env:
+        XDEBUG_MODE: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# Build tools
+/coverage/
+/vendor/
+/test/phpunit/_cache/
+/.phpunit.result.cache
+/composer.lock
+
+# Developer environment
 .buildpath
 .project
 .settings
@@ -7,9 +15,3 @@ ehthumbs.db
 Icon?
 Thumbs.db
 *.komodoproject
-composer.lock
-vendor/
-x_*
-X_*
-_*
-.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
 			"phpunit",
 			"minus-x check ."
 		],
+		"cover": "phpunit --coverage-text --coverage-html coverage/ --coverage-clover coverage/clover.xml",
 		"fix": [
 			"minus-x fix .",
 			"phpcbf"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,5 +12,12 @@
 			<directory>./test/phpunit</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+		<!-- TODO: use <coverage includeUncoveredFiles> in PHPUnit 9.3+ -->
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">lib/</directory>
+			<file>lessc.inc.php</file>
+		</whitelist>
+	</filter>
 </phpunit>
 


### PR DESCRIPTION
* Shorten names a bit to fit within GitHub's tooltip interface.

* Use Debian's PHP packages, via GitHub's official images, instead of a third-party binary installed via a JavaScript module.

* Add coverage with xdebug.

  In addition to clover XML and HTML (for local viewing), I've also enabled coverage-text to view coverage in CI. This is instead of e.g. coveralls.io, since we may be moving this to Wikimedia Git, where we'd not use that either, in favour of doc.wikimedia.org.

As of writing:

```
 Summary:                    
  Classes: 15.79% (9/57)     
  Methods: 61.65% (352/571)  
  Lines:   79.52% (3491/4390)
```