### PR TITLE
build: Set .map files as binary to improve git-grep experience

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 /.* export-ignore
 /test/ export-ignore
 /phpunit.xml export-ignore
+/test/**/*.map binary
+/test/**/*.min.js binary


### PR DESCRIPTION
The git-grep command will still mention that the file matches,
and the results can be viewed as-needed by using `-a` or `--text`.