### PR TITLE
Don't attempt to pass URLs to file_exists()

### DIFF
--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -436,7 +436,7 @@ class Less_Parser {
 	 * @return Less_Tree_Ruleset|Less_Parser
 	 */
 	public function parseFile( $filename, $uri_root = '', $returnRoot = false ) {
-		if ( !file_exists( $filename ) ) {
+		if ( !preg_match('#^https?://#', $filename) && !file_exists( $filename ) ) {
 			$this->Error( sprintf( 'File `%s` not found.', $filename ) );
 		}
 


### PR DESCRIPTION
file_exists() will return false for a file on a remote server.
This method could need a rewrite to handle URLs  e.g. Google Fonts.