### PR TITLE
Import: Output all imported URLs as literals regardless of extension

### DIFF
--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -2658,7 +2658,7 @@ class Less_Parser {
 	}
 
 	public static function AbsPath( $path, $winPath = false ) {
-		if ( strpos( $path, '//' ) !== false && preg_match( '_^(https?:)?//\\w+(\\.\\w+)+/\\w+_i', $path ) ) {
+		if ( strpos( $path, '//' ) !== false && preg_match( '/^(https?:)?\/\//i', $path ) ) {
 			return $winPath ? '' : false;
 		} else {
 			$path = realpath( $path );

--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -41,7 +41,10 @@ class Less_Tree_Import extends Less_Tree {
 				$this->css = !isset( $this->options['less'] ) || !$this->options['less'] || $this->options['inline'];
 			} else {
 				$pathValue = $this->getPath();
-				if ( $pathValue && preg_match( '/css([\?;].*)?$/', $pathValue ) ) {
+				// Leave any ".css" file imports as literals for the browser.
+				// Also leave any remote HTTP resources as literals regardless of whether
+				// they contain ".css" in their filename.
+				if ( $pathValue && preg_match( '/^(https?:)?\/\/|\.css$/i', $pathValue ) ) {
 					$this->css = true;
 				}
 			}

--- a/test/Fixtures/less.php/css/imports.css
+++ b/test/Fixtures/less.php/css/imports.css
@@ -1,3 +1,7 @@
+@import url("https://fonts.example.org/icon?family=Foo+Bar");
+@import url("http://fonts.example.org/icon?family=Foo+Bar");
+@import url("//fonts.example.org/icon?family=Foo+Bar");
+
 @media screen and (max-width: 1024px) {
   .import-a {
     color: #fff;

--- a/test/Fixtures/less.php/less/imports.less
+++ b/test/Fixtures/less.php/less/imports.less
@@ -1,3 +1,7 @@
+@import url("https://fonts.example.org/icon?family=Foo+Bar");
+@import url("http://fonts.example.org/icon?family=Foo+Bar");
+@import url("//fonts.example.org/icon?family=Foo+Bar");
+
 @media screen and (max-width: 1024px) {
 	@import "imports/a.less";
 }


### PR DESCRIPTION
The regex that was meant to handle this already accounted for a lot of edge cases, such as `/css` endpoints without `.css`, and query parameters like `/css?foo` or `/css;foo`, all to carefully avoid matching things like `foocss.less` or `foo.css.bar.less`.

However can still be any number of CSS resources served from URLs that don't match that pattern.

Instead of trying to match the path segment, just match the start of the URL, which should take care of any edge cases, given that we don't allow importing remote Less code for compilation anyway.

This is an amendment to https://github.com/wikimedia/less.php/pull/28. I've kept commit authorship credit in-tact.

Fixes https://github.com/wikimedia/less.php/issues/27.
Closes https://github.com/wikimedia/less.php/pull/68.