### PR TITLE
Import: Fix php warning when importing with variable name

### DIFF
--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -106,7 +106,11 @@ class Less_Tree_Import extends Less_Tree {
 		if ( $this->path instanceof Less_Tree_Quoted ) {
 			$path = $this->path->value;
 			$path = ( isset( $this->css ) || preg_match( '/(\.[a-z]*$)|([\?;].*)$/', $path ) ) ? $path : $path . '.less';
-		} else if ( $this->path instanceof Less_Tree_URL ) {
+
+		// During the first pass, Less_Tree_URL may contain a Less_Tree_Variable (not yet expanded),
+		// and thus has no value property defined yet. Return null until we reach the next phase.
+		// https://github.com/wikimedia/less.php/issues/29
+		} else if ( $this->path instanceof Less_Tree_URL && !( $this->path->value instanceof Less_Tree_Variable ) ) {
 			$path = $this->path->value->value;
 		} else {
 			return null;

--- a/test/Fixtures/less.php/css/imports.css
+++ b/test/Fixtures/less.php/css/imports.css
@@ -6,3 +6,6 @@
     color: #fff;
   }
 }
+.import-b {
+  color: #111;
+}

--- a/test/Fixtures/less.php/less/imports.less
+++ b/test/Fixtures/less.php/less/imports.less
@@ -5,3 +5,6 @@
 @media screen and (max-width: 1024px) {
 	@import "imports/a.less";
 }
+
+@filetoimport: "imports/b.less";
+@import url(@filetoimport);

--- a/test/Fixtures/less.php/less/imports/b.less
+++ b/test/Fixtures/less.php/less/imports/b.less
@@ -1,0 +1,3 @@
+.import-b {
+    color: #111;
+}


### PR DESCRIPTION
The import worked fine, but it produced a warning as side-effect.

Prevent this by recognising that some URL nodes assigned to $path during the first phase have $value set to a Variable node (instead of an Anonymous node), and thus don't have a value property themselves yet.

Fixes https://github.com/wikimedia/less.php/issues/29.
Fixes https://github.com/wikimedia/less.php/issues/32.