### PR TITLE
Compatibility to BrianHenryIE/strauss

### DIFF
--- a/lib/Less/Visitor.php
+++ b/lib/Less/Visitor.php
@@ -17,7 +17,7 @@ class Less_Visitor {
 			return $node;
 		}
 
-		$prefixClassName = str_replace("Less_Visitor", "", __CLASS__);
+		$prefixClassName = str_replace("Less"."_"."Visitor", "", __CLASS__);
 		$funcName = 'visit' . str_replace( [ $prefixClassName . 'Less_Tree_', '_' ], '', get_class( $node ) );
 
 		if ( isset( $this->_visitFnCache[$funcName] ) ) {

--- a/lib/Less/Visitor.php
+++ b/lib/Less/Visitor.php
@@ -16,7 +16,10 @@ class Less_Visitor {
 		if ( !$node || !is_object( $node ) ) {
 			return $node;
 		}
-		$funcName = 'visit' . str_replace( [ 'Less_Tree_', '_' ], '', get_class( $node ) );
+
+		$prefixClassName = str_replace("Less_Visitor", "", __CLASS__);
+		$funcName = 'visit' . str_replace( [ $prefixClassName . 'Less_Tree_', '_' ], '', get_class( $node ) );
+
 		if ( isset( $this->_visitFnCache[$funcName] ) ) {
 			$visitDeeper = true;
 			$newNode = $this->$funcName( $node, $visitDeeper );


### PR DESCRIPTION
**fix**: compatibility to [BrianHenryIE/strauss](https://github.com/BrianHenryIE/strauss)

This is a very special modification for only some users, but which are currently impossible to use this helpfull library

[BrianHenryIE/strauss](https://github.com/BrianHenryIE/strauss) library will prefix dependency classnames with a custom string to prevent dependency collision.

For example classname will be changed from **Less_Visitor** to **ModA_Less_Visitor**. 
So multiple versions of same library can be used in ecosystems, where external modules can be installed from different developers.

The modified line generate function calls from class names, by removing the "namespace" part of class name.
When there is a custom prefix, then this line is not working.

The small modification check for custom prefix and append them to classname replacement.
Not a perfect solution. Maybe there is a better one.