### PR TITLE
Fixed deprecated using null as key parameter for array_key_exists()

### DIFF
--- a/lib/Less/Tree/Mixin/Definition.php
+++ b/lib/Less/Tree/Mixin/Definition.php
@@ -239,7 +239,8 @@ class Less_Tree_Mixin_Definition extends Less_Tree_Ruleset {
 		$allArgsCnt = count( $args );
 		$requiredArgsCnt = 0;
 		foreach ( $args as $arg ) {
-			if ( !array_key_exists( $arg['name'], $this->optionalParameters ) ) {
+            $name = isset( $arg['name'] ) ? (string)$arg['name'] : '';
+			if ( !array_key_exists( $name, $this->optionalParameters ) ) {
 				$requiredArgsCnt++;
 			}
 		}


### PR DESCRIPTION
To address the following issue, I have created this PR

https://github.com/wikimedia/less.php/issues/134